### PR TITLE
feature: add crawling optimizer

### DIFF
--- a/internal/console/imagesAll.go
+++ b/internal/console/imagesAll.go
@@ -18,4 +18,5 @@ var getAllImagesCmd = &cobra.Command{
 func init() {
 	imagesCmd.AddCommand(getAllImagesCmd)
 	getAllImagesCmd.PersistentFlags().Int("request-delay-sec", 0, "Make every request delayed as input (ms)")
+	getAllImagesCmd.PersistentFlags().Int("max-seq-failure", 10, "Add division skipping when sequentially absent crawling is failed / not found")
 }

--- a/internal/console/imagesAll.go
+++ b/internal/console/imagesAll.go
@@ -18,5 +18,5 @@ var getAllImagesCmd = &cobra.Command{
 func init() {
 	imagesCmd.AddCommand(getAllImagesCmd)
 	getAllImagesCmd.PersistentFlags().Int("request-delay-sec", 0, "Make every request delayed as input (ms)")
-	getAllImagesCmd.PersistentFlags().Int("max-seq-failure", 10, "Add division skipping when sequentially absent crawling is failed / not found")
+	getAllImagesCmd.PersistentFlags().Int("max-seq-failure", 10, "skip and increment division if sequentially failed to get images from given NPM when sequentially absent crawling is failed / not found")
 }

--- a/internal/feature/getAllProfileImage.go
+++ b/internal/feature/getAllProfileImage.go
@@ -10,6 +10,7 @@ func GetAllProfileImage(cmd *cobra.Command, args []string) {
 	util := utility.New()
 
 	delay := util.GetRequestDelaySecFlag(cmd)
+	maxSeqFailure := util.GetMaxSeqFailureCount(cmd)
 
-	util.GetAllProfileImage(delay)
+	util.GetAllProfileImage(delay, maxSeqFailure)
 }

--- a/internal/utility/NPMIncrementor.go
+++ b/internal/utility/NPMIncrementor.go
@@ -15,6 +15,8 @@ type NPMIncrementor struct {
 	CurrentDivision    string
 	CurrentAbsent      string
 	GeneratedCount     int
+	SequentialFailureCount int
+	MaxSequentialFailure int
 	IsMaxReached       bool
 }
 
@@ -28,6 +30,8 @@ func NewIncrementor(start, to string) *NPMIncrementor {
 		CurrentDivision:    start[4:7],
 		CurrentAbsent:      start[7:10],
 		GeneratedCount:     0,
+		SequentialFailureCount: 0, // this and max seq set to this val
+		MaxSequentialFailure: -1,	// so will not take effect if not needed
 		IsMaxReached:       false,
 	}
 }
@@ -133,6 +137,15 @@ func (n *NPMIncrementor) incrementAbsent() {
 	tmp, _ := strconv.Atoi(n.CurrentAbsent)
 	tmp++
 
+	if n.SequentialFailureCount > n.MaxSequentialFailure {
+		n.CurrentAbsent = "000"
+
+		n.ResetSeqFailureCount()
+		n.incrementDivision()
+
+		return
+	}
+
 	if tmp == 1000 {
 		n.CurrentAbsent = "000"
 		n.incrementDivision()
@@ -157,4 +170,16 @@ func (n *NPMIncrementor) GetCurrent() string {
 	n.Current = fmt.Sprintf("%s%s%s%s", n.CurrentYear, n.CurrentDepartement, n.CurrentDivision, n.CurrentAbsent)
 
 	return n.Current
+}
+
+func (n *NPMIncrementor) SetMaxSequentialFailure(value int) {
+	n.MaxSequentialFailure = value
+}
+
+func (n *NPMIncrementor) IncrementSeqFailureCount() {
+	n.SequentialFailureCount++
+}
+
+func (n *NPMIncrementor) ResetSeqFailureCount() {
+	n.SequentialFailureCount = 0
 }

--- a/internal/utility/getFlagValue.go
+++ b/internal/utility/getFlagValue.go
@@ -17,3 +17,15 @@ func (u *Utility) GetRequestDelaySecFlag(cmd *cobra.Command) int {
 
 	return delay
 }
+
+func (u *Utility) GetMaxSeqFailureCount(cmd *cobra.Command) int {
+	maxFailureCount, err := cmd.Flags().GetInt("max-seq-failure")
+
+	if err != nil {
+		log.Println("Invalid / no max sequential failure flag present. Using default value 10")
+
+		return 10
+	}
+
+	return maxFailureCount
+}

--- a/internal/utility/image.getAll.go
+++ b/internal/utility/image.getAll.go
@@ -2,11 +2,15 @@ package utility
 
 import "time"
 
-func (u *Utility) GetAllProfileImage(delay int) {
+func (u *Utility) GetAllProfileImage(delay, maxSeqFailure int) {
 	i := NewIncrementor("0000000000", "9999999999")
+	i.SetMaxSequentialFailure(maxSeqFailure)
 
 	for !i.IsMaxReached {
-		u.GetImageFromNPM(i.GetCurrent())
+		if err := u.GetImageFromNPM(i.GetCurrent()); err != nil {
+			i.IncrementSeqFailureCount()
+		}
+
 		i.Next()
 
 		time.Sleep(time.Duration(delay) * time.Second)

--- a/internal/utility/image.getSingle.go
+++ b/internal/utility/image.getSingle.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 )
 
-func (u *Utility) GetImageFromNPM(NPM string) {
+func (u *Utility) GetImageFromNPM(NPM string) error {
 	for _, ext := range POSSIBLE_IMAGE_EXT {
 		res, err := RequestImage(fmt.Sprintf("%s%s%s", IMAGE_URL, NPM, ext))
 
@@ -14,9 +14,11 @@ func (u *Utility) GetImageFromNPM(NPM string) {
 
 			u.WriteLog(fmt.Sprintf("Image for NPM: %s found.", NPM))
 
-			return
+			return nil
 		}
 	}
 
 	u.WriteLog(fmt.Sprintf("Image for NPM: %s is not found.", NPM))
+
+	return fmt.Errorf("Image for NPM: %s is not found.", NPM)
 }


### PR DESCRIPTION
Add optimizer to skip and increment division if sequentially failed to get images from given NPM. If happen, current absent will be set to 000, and the current division will increased