### PR TITLE
feature-fix: add-retry-request-when-get-image-error-from-siakadu-server

### DIFF
--- a/internal/utility/requestImage.go
+++ b/internal/utility/requestImage.go
@@ -12,7 +12,9 @@ func RequestImage(link string) (io.ReadCloser, error) {
 	res, err := http.Get(link)
 
 	if err != nil {
-		log.Panic(err.Error())
+		log.Printf("Failed to request image for %s because: %s", link, err.Error())
+		log.Println("Retrying....")
+		RequestImage(link)
 	}
 
 	if res.StatusCode != 200 {


### PR DESCRIPTION
v0.3.2

fix panic when request from siakadu server for profile image (http.Get) returning error. Now if it's error, app will retry to request to the same link indefinitely