### PR TITLE
v0.3.4-feature-fix: add npm validator before creating npm incrementor

### DIFF
--- a/internal/utility/NPMIncrementor.go
+++ b/internal/utility/NPMIncrementor.go
@@ -2,37 +2,45 @@ package utility
 
 import (
 	"fmt"
+	"log"
+	"os"
 	"strconv"
 	"time"
 )
 
 type NPMIncrementor struct {
-	Start              string
-	To                 string
-	Current            string
-	CurrentYear        string
-	CurrentDepartement string
-	CurrentDivision    string
-	CurrentAbsent      string
-	GeneratedCount     int
+	Start                  string
+	To                     string
+	Current                string
+	CurrentYear            string
+	CurrentDepartement     string
+	CurrentDivision        string
+	CurrentAbsent          string
+	GeneratedCount         int
 	SequentialFailureCount int
-	MaxSequentialFailure int
-	IsMaxReached       bool
+	MaxSequentialFailure   int
+	IsMaxReached           bool
 }
 
 func NewIncrementor(start, to string) *NPMIncrementor {
+	if err := EnsureNoBackwardNPM(start, to); err != nil {
+		log.Printf("%s. Exiting....", err.Error())
+
+		os.Exit(1)
+	}
+
 	return &NPMIncrementor{
-		Start:              start,
-		To:                 to,
-		Current:            start,
-		CurrentYear:        start[0:2],
-		CurrentDepartement: start[2:4],
-		CurrentDivision:    start[4:7],
-		CurrentAbsent:      start[7:10],
-		GeneratedCount:     0,
-		SequentialFailureCount: 0, // this and max seq set to this val
-		MaxSequentialFailure: -1,	// so will not take effect if not needed
-		IsMaxReached:       false,
+		Start:                  start,
+		To:                     to,
+		Current:                start,
+		CurrentYear:            start[0:2],
+		CurrentDepartement:     start[2:4],
+		CurrentDivision:        start[4:7],
+		CurrentAbsent:          start[7:10],
+		GeneratedCount:         0,
+		SequentialFailureCount: 0,  // this and max seq set to this val
+		MaxSequentialFailure:   -1, // so will not take effect if not needed
+		IsMaxReached:           false,
 	}
 }
 

--- a/internal/utility/validateNPM.go
+++ b/internal/utility/validateNPM.go
@@ -18,3 +18,31 @@ func ValidateNPM(NPM string) error {
 
 	return nil
 }
+
+func EnsureNoBackwardNPM(first, second string) error {
+	start, err := strconv.Atoi(first)
+
+	if err != nil {
+		return fmt.Errorf("NPM value is invalid: %s", first)
+	}
+
+	to, err := strconv.Atoi(second)
+
+	if err != nil {
+		return fmt.Errorf("NPM value is invalid: %s", first)
+	}
+
+	if start > to {
+		return fmt.Errorf("backward NPM value detected: %s > %s", first, second)
+	}
+
+	if err := ValidateNPM(first); err != nil {
+		return fmt.Errorf("invalid value for NPM: %s", first)
+	}
+
+	if err := ValidateNPM(second); err != nil {
+		return fmt.Errorf("invalid value for NPM: %s", second)
+	}
+
+	return nil
+}


### PR DESCRIPTION
v0.3.4

Add NPM validator before creating NPM incrementor. Previously, if the NPM is invalid, program crashes because failure to split the string. Now, if the NPM is invalid, or if NPM is backward, the program is exiting.